### PR TITLE
hookAddTwigExtension() => addTwigExtension()

### DIFF
--- a/typogrify/TypogrifyPlugin.php
+++ b/typogrify/TypogrifyPlugin.php
@@ -23,7 +23,7 @@ class TypogrifyPlugin extends BasePlugin
         return 'http://withchief.com';
     }
 
-    public function hookAddTwigExtension()
+    public function addTwigExtension()
     {
         Craft::import('plugins.typogrify.twigextensions.TypogrifyTwigExtension');
         return new TypogrifyTwigExtension();


### PR DESCRIPTION
"hook" hasn't been necessary since Craft was Blocks.
